### PR TITLE
Fix typo in Simple-Thumbnail-Generator

### DIFF
--- a/src/simple-thumbnail-generator.js
+++ b/src/simple-thumbnail-generator.js
@@ -203,7 +203,7 @@ SimpleThumbnailGenerator.prototype._registerGeneratorListeners = function() {
 
 		this._logger.debug("Thumbnails changed.", thumbnail);
 		this._updateManifest();
-		this._emit("newThumbnail". thumbnail);
+		this._emit("newThumbnail", thumbnail);
 		this._emit("thumbnailsChanged");
 	});
 };


### PR DESCRIPTION
 The newThumbnail event emit statement inside of Simple-Thumbnail-Generator had a period instead of a comma and would not emit as expected.
