### PR TITLE
fix passing of height & width variables to ThumbnailGenerator

### DIFF
--- a/src/thumbnail-generator.js
+++ b/src/thumbnail-generator.js
@@ -37,8 +37,8 @@ function ThumbnailGenerator(options) {
 		initialThumbnailCount: null,
 		interval: null,
 		targetThumbnailCount: !options.interval ? 30 : null,
-		thumbnailWidth: !options.thumbnailHeight ? 150 : null,
-		thumbnailHeight: null,
+		thumbnailWidth: options.width ? options.width : (!options.height ? 150 : null),
+		thumbnailHeight: options.height ? options.height : null,
 		outputNamePrefix: null,
 		logger: Logger.get('ThumbnailGenerator')
 	}, options || {});


### PR DESCRIPTION
Height and width in the options being passed to the ThumbnailGenerator were stored in keys named 'height' and 'width', while the code expected them to be named 'thumbnailHeight' and 'thumbnailWidth'.
