### PR TITLE
strip query param after extension

### DIFF
--- a/src/thumbnail-generator.js
+++ b/src/thumbnail-generator.js
@@ -524,6 +524,7 @@ ThumbnailGenerator.prototype._BadStatusCodeException = function(statusCode) {
 util.inherits(ThumbnailGenerator.prototype._BadStatusCodeException, Error);
 
 ThumbnailGenerator.prototype._getExtension = function(name) {
+	name = name.replace(/\?.*$/, '')
 	var i = name.lastIndexOf(".");
 	if (i === -1) {
 		return "";

--- a/src/thumbnail-generator.js
+++ b/src/thumbnail-generator.js
@@ -12,6 +12,7 @@ var config = require("./config");
 var utils = require("./utils");
 
 var ffmpegTimeout = config.ffmpegTimeout;
+const extensionRegex = /\.([^.?#;]+)[^.]*$/;
 
 /**
  * Generates thumbnails from a HLS stream and emits them as they are taken.
@@ -524,12 +525,8 @@ ThumbnailGenerator.prototype._BadStatusCodeException = function(statusCode) {
 util.inherits(ThumbnailGenerator.prototype._BadStatusCodeException, Error);
 
 ThumbnailGenerator.prototype._getExtension = function(name) {
-	name = name.replace(/\?.*$/, '')
-	var i = name.lastIndexOf(".");
-	if (i === -1) {
-		return "";
-	}
-	return name.substring(i+1);
+	const res = extensionRegex.exec(name);
+	return res ? res[1] : '';
 };
 
 ThumbnailGenerator.prototype._wait = function(time) {


### PR DESCRIPTION
so I found a bug where if an extension have query param for example in my case:
.ts?base64 there will error throw by name is too long on mac and ubuntu so i just added a line to strip everything after extension 