### PR TITLE
add `ignorePlaylist404` and `playlistRetryCount` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ These are the options:
 - **targetThumbnailCount**: The default number of thumbnails that should be generated over the duration of the stream. Defaults to 30. This will be recalculated if the stream duration changes.
 - **width**: The default width of the thumbnails to generate (px). If omitted this will be calculated automatically from the height, or default to 150.
 - **height**: The default height of the thumbnails to generate (px). If omitted this will be calculated automatically from the width.
+- **ignorePlaylist404**: Do not abort immediately if the playlist response is a 404. Defaults to false.
+- **playlistRetryCount**: The number of times to retry downloding the playlist on an error. Defaults to 2. Can be Infinity for unlimited retries.
 
 E.g. Service: `hls-live-thumbnails --secret "super-secret" --targetThumbnailCount 20 --width 300`
 E.g. Standalone: `hls-live-thumbnails https://devimages.apple.com.edgekey.net/streaming/examples/bipbop_4x3/bipbop_4x3_variant.m3u8  --width 300`

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "hls-live-thumbnails",
       "version": "1.6.1",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Setting `ignorePlaylist404` to `true` and `playlistRetryCount` to `Infinity` means that you can start a generator when your playlist isn't available yet and it will keep retrying.

closes #24